### PR TITLE
VSCode用の設定ファイルを追加

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,8 @@
 {
-  "recommendations": ["esbenp.prettier-vscode"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "MS-CEINTL.vscode-language-pack-ja",
+    "yzhang.markdown-all-in-one",
+    "mhutchie.git-graph"
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "依存関係のインストール",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["install"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Docusaurusを起動",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
# やったこと

- 以下の拡張機能を推奨するように設定
  - prettier
  - 日本語化拡張
  - Markdown All in One
  - Git Graph

  これ以外で推奨に名前が上がっていた拡張に関しては必須ではなさそうだったので除外しました
- デバッグと実行のショートカットを追加
- 保存時にprettierのフォーマットを実行するように設定

# なぜやるか

VSCodeの環境構築を円滑化するため