### PR TITLE
PRにビルドが通るかのテストを追加

### DIFF
--- a/.github/workflows/pr_test_build.yml
+++ b/.github/workflows/pr_test_build.yml
@@ -1,0 +1,22 @@
+name: Test Build
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Test Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+      - name: Build website
+        run: npm run build


### PR DESCRIPTION
# やったこと
github actionsにPR時のテストを追加

# なぜやるか
#2 #3 をビルドに失敗する状態でマージしてしまったのでこれを防ぐ目的

# 注意事項
このリポジトリはpublicなのでactionsの実行時間制限を受けないがprivateリポジトリだと実行時間の枠を消費するのでこのまま使う場合は注意が必要