### PR TITLE
リンク色を見やすいように変更

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -18,7 +18,7 @@
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
+[data-theme="dark"] {
   --ifm-color-primary: #25c2a0;
   --ifm-color-primary-dark: #21af90;
   --ifm-color-primary-darker: #1fa588;
@@ -27,4 +27,16 @@
   --ifm-color-primary-lighter: #32d8b4;
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+}
+
+a {
+  --ifm-link-color: #00aaff;
+  --ifm-link-hover-color: #0077cc;
+  --ifm-link-decoration: underline;
+}
+
+a[class] {
+  --ifm-link-color: #25c2a0;
+  --ifm-link-hover-color: #25c2a0;
+  --ifm-link-decoration: none;
 }


### PR DESCRIPTION
# やったこと
本文中のアンカーリンクの色を水色に変更

# なぜやるか
本文の文字色とアンカーリンクの色が同じだったため、見分けがつくように変更