### PR TITLE
Actionsの依存関係を更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/pr_test_build.yml
+++ b/.github/workflows/pr_test_build.yml
@@ -10,10 +10,10 @@ jobs:
     name: Test Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/pr_test_format.yml
+++ b/.github/workflows/pr_test_format.yml
@@ -10,13 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: 20
+          cache: npm
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
# やったこと
Actionsの各依存関係を更新
- actions/checkoutをv4に
- actions/setup-nodeをv4に
  - nodeを20に

# なぜやるか
actions/setup-node v3にはキャッシュが更新された際に完了に2分かかってしまうという不具合があったので更新
ref: https://github.com/actions/setup-node/issues/878

これに合わせて周りの依存関係を更新