### PR TITLE
lefthookがwindowsでも正しく動くように修正

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,4 +9,4 @@ pre-commit:
   commands:
     prettier:
       glob: "**/*.md"
-      run: npx prettier --write {staged_files}
+      run: npx prettier --write "{staged_files}"


### PR DESCRIPTION
# やったこと
prettierに渡すファイルパスをダブルクォートに変更

# なぜやるか
windowsにおいて、ファイルパスがシングルクォートだとprettierが意図したとおりに機能しなかったため