### PR TITLE
PR時に自動フォーマットするように変更

### DIFF
--- a/.github/workflows/pr_test_format.yml
+++ b/.github/workflows/pr_test_format.yml
@@ -1,9 +1,11 @@
-name: PR Format Check
+name: PR Format
 
 on:
   pull_request:
     branches:
       - master
+    paths:
+      - "**/*.md"
 
 jobs:
   format-check:
@@ -19,5 +21,16 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Run Prettier check
-        run: npx prettier --check "./**/*.md"
+      - name: Run Prettier format
+        run: npx prettier --write "./**/*.md"
+
+      - name: Check for changes
+        id: git_diff
+        run: |
+          git diff --exit-code || echo "changes"
+
+      - uses: stefanzweifel/git-auto-commit-action@v3.0.0
+        if: steps.git_diff.outputs.changes == 'changes'
+        with:
+          commit_message: Apply Prettier Change
+          ref: ${{ github.head_ref }}


### PR DESCRIPTION
# やったこと
- PRのフォーマットチェックをフォーマットに変更
- mdフィアルが変更されていない場合はCIの実行をスキップするように変更

# なぜやるか
- 非エンジニアの人の体験の向上
  - VSCodeを使わないということがわかったのでこちら側でフォーマットをかけたほうが良さそう
